### PR TITLE
Needed choice on python 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Requirements and Installation
 
 For basic functionality:
 
-* Python 2.7 or 3
+* Python 2.6 or 3
 
 To install, just run:
 

--- a/choice/basicterm.py
+++ b/choice/basicterm.py
@@ -34,16 +34,16 @@ class BasicTermMenu(object):
             start = curr_page * self.PAGE_SIZE
             end = start + self.PAGE_SIZE
             for i, c in enumerate(self.choices[start:end]):
-                print(" {}: {}".format(i, c[1]))
+                print(" {0}: {1}".format(i, c[1]))
             if self.global_actions is not None:
                 print()
                 for ga in self.global_actions:
                     if ga[0] == ga[1]:
-                        print("    {}".format(ga[0]))
+                        print("    {0}".format(ga[0]))
                     else:
-                        print(" {}: {}".format(ga[0], ga[1]))
+                        print(" {0}: {1}".format(ga[0], ga[1]))
 
-            print("\nEnter number or name; return for next page")
+            print(linesep + "Enter number or name; return for next page")
             resp = input('? ').strip()
             print()
             if len(resp) == 0:
@@ -60,8 +60,8 @@ class BasicTermMenu(object):
     def pick_action(self):
         print("Select an action:")
         for i, ac in enumerate(self.actions):
-            print(" {}: {}".format(i, ac[1]))
-        print(" {}: back".format(self.BACK_CHAR))
+            print(" {0}: {1}".format(i, ac[1]))
+        print(" {0}: back".format(self.BACK_CHAR))
         resp = input('? ')
         print()
         return str(resp)
@@ -77,7 +77,7 @@ class BasicTermMenu(object):
                     break
             else:
                 # Global action?
-                for ga in self.global_actions:
+                for ga in self.global_actions or []:
                     if resp == ga[0]:
                         return None, ga[0]
 
@@ -88,7 +88,7 @@ class BasicTermMenu(object):
                         break
 
             if choice is None:
-                print("{} is not a valid choice".format(resp))
+                print("{0} is not a valid choice".format(resp))
 
         assert choice is not None
         if self.actions is None or len(self.actions) == 1:
@@ -113,7 +113,7 @@ class BasicTermMenu(object):
                         action = ac
                         break
             if action is None:
-                print("{} is not a valid choice".format(resp))
+                print("{0} is not a valid choice".format(resp))
 
         assert action is not None
         return choice[0], action[0]
@@ -125,7 +125,7 @@ class BasicTermInput(object):
         self.parser = parser
 
     def ask(self):
-        resp = input('{}:\n? '.format(self.prompt))
+        resp = input(self.prompt + ':' + linesep + '? ')
         try:
             return self.parser(resp)
         except ValueError:
@@ -142,7 +142,7 @@ class BasicTermBinaryChoice(object):
         if self.default is None:
             options = '(y/n)'
         elif self.default == True:
-            options = '{}\n(Y/n)'
+            options = '(Y/n)'
         elif self.default == False:
             options = '(y/N)'
         resp = input(self.prompt + linesep + options + '? ').lower().strip()

--- a/choice/basicterm.py
+++ b/choice/basicterm.py
@@ -1,7 +1,12 @@
 from __future__ import division, absolute_import, print_function, unicode_literals
 
 import sys
-if sys.version_info.major < 3:
+
+try:
+    if sys.version_info.major < 3:
+        input = raw_input
+except AttributeError:
+    # Python 2.6 has a version tuple
     input = raw_input
 
 from choice.util import idNameList

--- a/choice/basicterm.py
+++ b/choice/basicterm.py
@@ -9,6 +9,8 @@ except AttributeError:
     # Python 2.6 has a version tuple
     input = raw_input
 
+from os import linesep
+
 from choice.util import idNameList
 
 class BasicTermMenu(object):
@@ -138,12 +140,12 @@ class BasicTermBinaryChoice(object):
 
     def ask(self):
         if self.default is None:
-            prompt = '{}\n(y/n)? '.format(self.prompt)
+            options = '(y/n)'
         elif self.default == True:
-            prompt = '{}\n(Y/n)? '.format(self.prompt)
+            options = '{}\n(Y/n)'
         elif self.default == False:
-            prompt = '{}\n(y/N)? '.format(self.prompt)
-        resp = input(prompt).lower().strip()
+            options = '(y/N)'
+        resp = input(self.prompt + linesep + options + '? ').lower().strip()
 
         if len(resp) == 0 and self.default is not None:
             return self.default

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='choice',
-      version='0.1',
+      version='0.2c1',
       author='Frank Huang',
       author_email='me@nongraphical.com',
       url='https://github.com/fyhuang/choice',

--- a/test/test.py
+++ b/test/test.py
@@ -1,20 +1,23 @@
 import choice
 
+def c():
+  print("Delete confirmed")
+
 # Get a yes or no response (default is no)
 confirm = choice.Binary('Are you sure you want to delete?', False).ask()
 if confirm:
-    deleteIt()
+    c()
 
 # Input an arbitrary value, check for correctness
 howmany = choice.Input('How many pies?', int).ask()
-print("You ordered {} pies".format(howmany))
+print("You ordered {0} pies".format(howmany))
 
 # Choose from a set of options
 entree = choice.Menu(['steak', 'potatoes', 'eggplant']).ask()
-print("You choice {}".format(entree))
+print("You choice {0}".format(entree))
 
 
-posts = ['post {}'.format(num) for num in range(15)]
+posts = ['post {0}'.format(num) for num in range(15)]
 
 resp = choice.Menu(posts, ['edit', 'delete', 'publish'], ['newpost', 'exit']).ask()
 print(resp)


### PR DESCRIPTION
... so I went ahead and created some changes to see that it works on python 2.6 as well. I also replaced the \n in the code to os.linesep, allowing this to work properly on non-Unix systems as well.

I've performed some basic tests (Menu with choices, Menu with choices _and_ actions, Input with int, Binary with default False) but it's probably a good idea to verify that it still works properly on python 2.7 and 3 as well

Thanks for a pretty useful module.
